### PR TITLE
Detect failed commands and relay their status

### DIFF
--- a/builder/project.py
+++ b/builder/project.py
@@ -34,9 +34,12 @@ class Project(threading.Thread):
         self.log()
         self.checkout()
         self.parse_manifest()
-        self.build()
+        rc = self.build()
         self.cleanup()
-        self.send_status('success')
+        if rc == 0:
+            self.send_status('success')
+        else:
+            self.send_status('failed')
 
     def log(self):
         logger.info('Repository: %s', self.url)
@@ -83,7 +86,7 @@ class Project(threading.Thread):
 
         logger.info('Running build command: %s', self.manifest['build'])
         p = Popen(self.manifest['build'], stdout=PIPE, shell=True)
-        sout, serr = p.communicate(timeout=1200)
+        sout, _ = p.communicate(timeout=1200)
         logger.info(sout.decode())
         os.chdir(ocwd)
         logger.info('Got return code %i', p.returncode)

--- a/builder/project.py
+++ b/builder/project.py
@@ -83,13 +83,15 @@ class Project(threading.Thread):
 
         logger.info('Running build command: %s', self.manifest['build'])
         p = Popen(self.manifest['build'], stdout=PIPE, shell=True)
-        while True:
-            line = p.stdout.readline().rstrip()
-            if not line:
-                break
-            logger.info(line.decode())
-        logger.info('Build complete!')
+        sout, serr = p.communicate(timeout=1200)
+        logger.info(sout.decode())
         os.chdir(ocwd)
+        logger.info('Got return code %i', p.returncode)
+        if p.returncode == 0:
+            logger.info('Build successful')
+        else:
+            logger.info('Build failed')
+        return p.returncode
 
     def cleanup(self):
         logger.info('Deleting project directory: %s', self.path)

--- a/builder/webhook.py
+++ b/builder/webhook.py
@@ -25,7 +25,7 @@ def webhook():
         except KeyError as e:
             pass
 
-        # Attempt to build 
+        # Attempt to build
         try:
             build(data['repository']['clone_url'],
                   data['after'],

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -51,8 +51,7 @@ def test_github_ping(client, github_ping_payload):
                        headers=[('X-Hub-Signature', 'sha1=eec3d1c560534e2608bed790b272f4c8507d6500')]
                        ).status_code == 200
 
-# This triggers a build and pytest doesnt like it. Disabling for now
-#def test_webhook(client, webhook_payload):
-#    assert client.post('/webhook', json=webhook_payload,
-#                       headers=[('X-Hub-Signature', 'sha1=40e44a4cf5c65b61155ad431125bddad88c98b50')]
-#                       ).status_code == 200
+def test_webhook(client, webhook_payload):
+    assert client.post('/webhook', json=webhook_payload,
+                       headers=[('X-Hub-Signature', 'sha1=f72b257a9c1bc1a2c508f06e18d59da780c3412e')]
+                       ).status_code == 200


### PR DESCRIPTION
This updates the mechanism used to get stdout and return code from build commands.  Now we're capturing the return code and using it to determine if a command was successful or not. 

Resolves #4 